### PR TITLE
Feat: Improved URL parsing for cookie domain

### DIFF
--- a/.idea/common.iml
+++ b/.idea/common.iml
@@ -18,6 +18,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/guzzlehttp/guzzle" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/guzzlehttp/promises" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/guzzlehttp/psr7" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/jeremykendall/php-domain-parser" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/katzien/php-mime-type" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/mustache/mustache" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/myclabs/deep-copy" />
@@ -30,14 +31,19 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpspec/prophecy" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-code-coverage" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-file-iterator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-invoker" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-text-template" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-timer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-token-stream" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/phpunit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/pimple/pimple" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/container" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/http-client" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/http-message" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/log" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/simple-cache" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/ralouphie/getallheaders" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/comparator" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/diff" />
@@ -50,12 +56,16 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/resource-operations" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/type" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/deprecation-contracts" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/http-foundation" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/mime" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-ctype" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-intl-idn" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-intl-normalizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-mbstring" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php70" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php72" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php80" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
     </content>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -54,6 +54,16 @@
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php72" />
       <path value="$PROJECT_DIR$/vendor/symfony/polyfill-intl-idn" />
       <path value="$PROJECT_DIR$/vendor/symfony/http-foundation" />
+      <path value="$PROJECT_DIR$/vendor/symfony/deprecation-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php80" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/code-unit" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-invoker" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-intl-normalizer" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php70" />
+      <path value="$PROJECT_DIR$/vendor/psr/http-client" />
+      <path value="$PROJECT_DIR$/vendor/psr/simple-cache" />
+      <path value="$PROJECT_DIR$/vendor/psr/log" />
+      <path value="$PROJECT_DIR$/vendor/jeremykendall/php-domain-parser" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.2" />

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "pimple/pimple": "3.*",
         "ralouphie/getallheaders": "3.*",
         "symfony/mime": "5.*",
-        "symfony/http-foundation": "^5.0"
+        "symfony/http-foundation": "^5.0",
+        "jeremykendall/php-domain-parser": "^5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*"

--- a/config/config.php
+++ b/config/config.php
@@ -49,11 +49,13 @@ $config['sess_regenerate_destroy'] = false;
 
 //  Cookie related variables
 $config['cookie_httponly'] = true;
+$config['cookie_domain']   = '';
 
 if (Config::get('CONF_COOKIE_DOMAIN')) {
 
     //  The developer has specified the specific domain to use for cookies
     $config['cookie_domain'] = Config::get('CONF_COOKIE_DOMAIN');
+
 } else {
 
     /**
@@ -61,25 +63,17 @@ if (Config::get('CONF_COOKIE_DOMAIN')) {
      * use of all specified BASE_URLs, i.e BASE_URL and SECURE_BASE_URL
      */
 
-    $config['cookie_domain'] = '';
-
-    /**
-     * Are the BASE_URL and SECURE_BASE_URL on the same domain? if so, cool,
-     * if not then...
-     */
-
     $sBaseDomain       = Url::extractRegistrableDomain(Config::get('BASE_URL'));
     $sSecureBaseDomain = Url::extractRegistrableDomain(Config::get('SECURE_BASE_URL'));
 
-    if ($baseDomain == $secureBaseDomain) {
+    if ($sBaseDomain === $sSecureBaseDomain) {
 
-        //  If the two match, then define it
-        $config['cookie_domain'] = $baseDomain;
+        $config['cookie_domain'] = $sBaseDomain;
 
     } else {
 
         $_ERROR = 'The <code>BASE_URL</code> and <code>SECURE_BASE_URL</code> ';
-        $_ERROR .= 'constants do not share the same domain, this can cause issues ';
+        $_ERROR .= 'values do not share the same domain, this can cause issues ';
         $_ERROR .= 'with sessions.';
 
         include Config::get('NAILS_COMMON_PATH') . 'errors/startup_error.php';

--- a/config/config.php
+++ b/config/config.php
@@ -1,9 +1,9 @@
 <?php
 
+use Nails\Common\Helper\Url;
 use Nails\Common\Service\FileCache;
 use Nails\Config;
 use Nails\Factory;
-use Nails\Functions;
 
 /* Load the base config file from the CodeIgniter package */
 require Config::get('NAILS_CI_APP_PATH') . 'config/config.php';
@@ -68,8 +68,8 @@ if (Config::get('CONF_COOKIE_DOMAIN')) {
      * if not then...
      */
 
-    $baseDomain       = Functions::getDomainFromUrl($config['base_url']);
-    $secureBaseDomain = Functions::getDomainFromUrl(Config::get('SECURE_BASE_URL'));
+    $sBaseDomain       = Url::extractRegistrableDomain(Config::get('BASE_URL'));
+    $sSecureBaseDomain = Url::extractRegistrableDomain(Config::get('SECURE_BASE_URL'));
 
     if ($baseDomain == $secureBaseDomain) {
 

--- a/src/Common/Helper/Url.php
+++ b/src/Common/Helper/Url.php
@@ -13,6 +13,8 @@
 namespace Nails\Common\Helper;
 
 use Nails\Bootstrap;
+use Nails\Common\Exception\FactoryException;
+use Nails\Common\Exception\NailsException;
 use Nails\Factory;
 use Pdp;
 use Psr\SimpleCache\InvalidArgumentException;
@@ -29,17 +31,18 @@ class Url
     // --------------------------------------------------------------------------
 
     /**
-     * Create a local URL based on your basepath. Segments can be passed via the
+     * Create a local URL based on your base path. Segments can be passed via the
      * first parameter either as a string or an array.
      *
      * @param mixed $sUrl         URI segments, either as a string or an array
      * @param bool  $bForceSecure Whether to force the url to be secure or not
      *
      * @return string
+     * @throws FactoryException
      */
     public static function siteUrl(string $sUrl = null, bool $bForceSecure = false): string
     {
-        $oConfig = \Nails\Factory::service('Config');
+        $oConfig = Factory::service('Config');
         return $oConfig::siteUrl($sUrl, $bForceSecure);
     }
 
@@ -54,11 +57,13 @@ class Url
      *
      * Overriding so as to call the post_system hook before exit()'ing
      *
-     * @param string  $sUrl              The uri to redirect to
-     * @param string  $sMethod           The redirect method
-     * @param integer $sHttpResponseCode The response code to send
+     * @param string $sUrl    The uri to redirect to
+     * @param string $sMethod The redirect method
+     * @param int    $iHttpResponseCode
      *
      * @return void
+     * @throws FactoryException
+     * @throws NailsException
      */
     public static function redirect(string $sUrl = null, string $sMethod = 'location', int $iHttpResponseCode = 302): void
     {
@@ -101,7 +106,7 @@ class Url
     public static function tel(string $sUrl = null, string $sTitle = '', string $sAttributes = ''): string
     {
         $sTitle = empty($sTitle) ? $sUrl : $sTitle;
-        $sUrl   = preg_replace('/[^\+0-9]/', '', $sUrl);
+        $sUrl   = preg_replace('/[^+0-9]/', '', $sUrl);
         $sUrl   = 'tel://' . $sUrl;
 
         return anchor($sUrl, $sTitle, $sAttributes);

--- a/src/Functions.php
+++ b/src/Functions.php
@@ -76,64 +76,6 @@ class Functions
     // --------------------------------------------------------------------------
 
     /**
-     * Attempts to get the top level part of a URL (i.e example.tld from sub.domains.example.tld).
-     * Hat tip: http://uk1.php.net/parse_url#104874
-     * BUG: 2 character TLD's break this
-     *
-     * @param string $sUrl The URL to analyse
-     *
-     * @return mixed        string on success, false on failure
-     * @todo: Try and fix this bug
-     *
-     */
-    public static function getDomainFromUrl($sUrl)
-    {
-        $sDomain = parse_url($sUrl, PHP_URL_HOST);
-        $bits    = explode('.', $sDomain);
-        $idz     = count($bits);
-        $idz     -= 3;
-
-        if (!isset($bits[($idz + 2)])) {
-
-            $aOut = false;
-
-        } elseif (strlen($bits[($idz + 2)]) == 2 && isset($bits[($idz + 2)])) {
-
-            $aOut = [
-                !empty($bits[$idz]) ? $bits[$idz] : false,
-                !empty($bits[$idz + 1]) ? $bits[$idz + 1] : false,
-                !empty($bits[$idz + 2]) ? $bits[$idz + 2] : false,
-            ];
-
-            $aOut = implode('.', array_filter($aOut));
-
-        } elseif (strlen($bits[($idz + 2)]) == 0) {
-
-            $aOut = [
-                !empty($bits[$idz]) ? $bits[$idz] : false,
-                !empty($bits[$idz + 1]) ? $bits[$idz + 1] : false,
-            ];
-
-            $aOut = implode('.', array_filter($aOut));
-
-        } elseif (isset($bits[($idz + 1)])) {
-
-            $aOut = [
-                !empty($bits[$idz + 1]) ? $bits[$idz + 1] : false,
-                !empty($bits[$idz + 2]) ? $bits[$idz + 2] : false,
-            ];
-            $aOut = implode('.', array_filter($aOut));
-
-        } else {
-            $aOut = false;
-        }
-
-        return $aOut;
-    }
-
-    // --------------------------------------------------------------------------
-
-    /**
      * Fetches the relative path between two directories
      * Hat tip: Thanks to Gordon for this one; http://stackoverflow.com/a/2638272/789224
      *

--- a/tests/Common/Helper/Url/ExtractRegistrableDomainTest.php
+++ b/tests/Common/Helper/Url/ExtractRegistrableDomainTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Common\Helper\Url;
+
+use Nails\Common\Helper\Url;
+use PHPUnit\Framework\TestCase;
+
+class ExtractRegistrableDomainTest extends TestCase
+{
+    /**
+     * @covers \Nails\Common\Helper\Url::extractRegistrableDomain()
+     */
+    public function test_accepts_string_as_first_arg(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Url::extractRegistrableDomain('example.com');
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * @covers \Nails\Common\Helper\Url::extractRegistrableDomain()
+     */
+    public function test_accepts_null_as_first_arg(): void
+    {
+        $this->expectNotToPerformAssertions();
+        Url::extractRegistrableDomain(null);
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * @covers \Nails\Common\Helper\Url::extractRegistrableDomain()
+     */
+    public function test_test_arg_is_required(): void
+    {
+        $this->expectException(\TypeError::class);
+        Url::extractRegistrableDomain();
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * @covers \Nails\Common\Helper\Url::extractRegistrableDomain()
+     */
+    public function test_does_not_accepts_other_data_type_as_first_arg(): void
+    {
+        $this->expectException(\TypeError::class);
+        Url::extractRegistrableDomain((object) []);
+    }
+
+    // --------------------------------------------------------------------------
+
+    /**
+     * @covers \Nails\Common\Helper\Url::extractRegistrableDomain()
+     */
+    public function test_returns_correct_domain(): void
+    {
+        $aTests = [
+            'my-domain.com',
+            'my-domain.co.uk',
+            'my-domain.io',
+        ];
+
+        foreach ($aTests as $sExpected) {
+
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain($sExpected));
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain($sExpected));
+
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain('http://' . $sExpected));
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain('https://' . $sExpected));
+
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain('http://subdomain.' . $sExpected));
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain('https://subdomain.' . $sExpected));
+
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain('http://deep.subdomain.' . $sExpected));
+            $this->assertEquals($sExpected, Url::extractRegistrableDomain('https://deep.subdomain.' . $sExpected));
+        }
+    }
+}

--- a/tests/Common/Service/FileCacheTest.php
+++ b/tests/Common/Service/FileCacheTest.php
@@ -88,7 +88,7 @@ class FileCacheTest extends TestCase
         );
 
         $sDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . md5(microtime(true));
-        $this->assertDirectoryNotExists($sDir);
+        $this->assertDirectoryDoesNotExist($sDir);
 
         new Driver($sDir);
     }
@@ -196,7 +196,7 @@ class FileCacheTest extends TestCase
         $this->assertFileExists(static::$sDirPrivate . 'existing-file.txt');
         $bResult = static::$oCache->delete('existing-file.txt');
         $this->assertTrue($bResult);
-        $this->assertFileNotExists(static::$sDirPrivate . 'existing-file.txt');
+        $this->assertFileDoesNotExist(static::$sDirPrivate . 'existing-file.txt');
     }
 
     // --------------------------------------------------------------------------
@@ -206,7 +206,7 @@ class FileCacheTest extends TestCase
      */
     public function testCanDeleteInvalidItemFromPrivateCache()
     {
-        $this->assertFileNotExists(static::$sDirPrivate . 'non-existing-file.txt');
+        $this->assertFileDoesNotExist(static::$sDirPrivate . 'non-existing-file.txt');
         $bResult = static::$oCache->delete('non-existing-file.txt');
         $this->assertFalse($bResult);
     }
@@ -233,7 +233,7 @@ class FileCacheTest extends TestCase
         );
 
         $sDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . md5(microtime(true));
-        $this->assertDirectoryNotExists($sDir);
+        $this->assertDirectoryDoesNotExist($sDir);
 
         new Driver\AccessibleByUrl($sDir);
     }
@@ -340,7 +340,7 @@ class FileCacheTest extends TestCase
     {
         $this->assertFileExists(static::$sDirPublic . 'existing-file.txt');
         static::$oCache->public()->delete('existing-file.txt');
-        $this->assertFileNotExists(static::$sDirPublic . 'existing-file.txt');
+        $this->assertFileDoesNotExist(static::$sDirPublic . 'existing-file.txt');
     }
 
     // --------------------------------------------------------------------------
@@ -350,7 +350,7 @@ class FileCacheTest extends TestCase
      */
     public function testCanDeleteInvalidItemFromPublicCache()
     {
-        $this->assertFileNotExists(static::$sDirPublic . 'non-existing-file.txt');
+        $this->assertFileDoesNotExist(static::$sDirPublic . 'non-existing-file.txt');
         $bResult = static::$oCache->public()->delete('non-existing-file.txt');
         $this->assertFalse($bResult);
     }


### PR DESCRIPTION
This PR adds `\Nails\Common\Heper\Url::extractRegistrableDomain` method to replace `\Nails\Functions::getDomainFromUrl`.

This new method resolves #79 